### PR TITLE
Fix BearQL parsing error

### DIFF
--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -319,6 +319,7 @@ pub(crate) mod test {
             ("./langs/rust//", Path("./langs/rust//".into())),
             ("//", Path("//".into())),
             (".//", Path(".//".into())),
+            ("/blog/", Path("/blog/".into())),
             (
                 "rust | langs go",
                 Or(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod db;
 pub mod utils;
 
 #[cfg(test)]
+#[cfg(not(tarpaulin_include))]
 #[ctor::ctor]
 fn init() {
     crate::utils::logging::setup_console_log();

--- a/src/utils/search.rs
+++ b/src/utils/search.rs
@@ -40,6 +40,8 @@ pub enum Path<'a> {
 pub enum RelativePath<'a> {
     #[parse("{0}/{1}")]
     Join(Keyword<'a>, &'a Self),
+    #[parse("{0}/")]
+    NameEndSlash(Keyword<'a>),
     #[parse("{0}")]
     Name(Keyword<'a>),
     #[parse("/")] // for tailing "/", "//" ... syntax
@@ -145,6 +147,11 @@ fn _path_to_str_parts<'a>(p: Path<'a>, parts: &mut Vec<&'a str>) {
             parts.push(item.into());
             false
         }
+        RelativePath::NameEndSlash(item) => {
+            parts.push(item.into());
+            parts.push("");
+            false
+        }
         RelativePath::ExtraSlash() => {
             parts.push("");
             parts.push("");
@@ -187,6 +194,7 @@ mod test {
             r#"title | #rust #langs"#,
             r#"title ( #rust  #langs )"#,
             r#"title ( #rust | #langs )"#,
+            r#"/blog/"#,
         ] {
             let rv = parse_query(&src, &out_arena, &err_arena);
             info!(?rv, ?src, "parsed");


### PR DESCRIPTION

```plain
  2024-08-07T11:08:33.068838Z DEBUG bearmark::db::search: parsing query, raw: "/blog/"
    at src/db/search.rs:21

  2024-08-07T11:08:33.068852Z DEBUG bearmark::db::search: parsed query, rv: And(Primitive(Path(Absolute(Name(blog)))), Primitive(Path(Root)))
```