### PR TITLE
ci: use develop branch for cargo-tarpaulin installation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           crate: cargo-tarpaulin
           git: https://github.com/xd009642/tarpaulin.git
+          branch: develop
       - name: cargo-install diesel_cli
         uses: baptiste0928/cargo-install@v3
         with:

--- a/bearmark-api/src/db/search.rs
+++ b/bearmark-api/src/db/search.rs
@@ -166,17 +166,16 @@ pub async fn search_bookmarks(
         let query = parse_query(query, &bump)?;
         builder = builder.filter(find_bookmarks(&query, cwd, &mut cwd_overwrited)?)
     }
-    if !cwd_overwrited {
-        if let Some(cwd) = cwd {
-            if cwd != "/" {
-                let expression = if cwd == "//" {
-                    Box::new(bookmarks::dsl::folder_id.is_null()) // special syntax. search bookmarks which are not in any folder
-                } else {
-                    find_bookmarks_in_path(cwd)?
-                };
-                builder = builder.filter(expression);
-            }
-        }
+    if !cwd_overwrited
+        && let Some(cwd) = cwd
+        && cwd != "/"
+    {
+        let expression = if cwd == "//" {
+            Box::new(bookmarks::dsl::folder_id.is_null()) // special syntax. search bookmarks which are not in any folder
+        } else {
+            find_bookmarks_in_path(cwd)?
+        };
+        builder = builder.filter(expression);
     }
 
     if before > 0 {


### PR DESCRIPTION
## Summary

Fix tarpaulin installation by using develop branch instead of master branch for cargo-tarpaulin installation.